### PR TITLE
feat: #33 pick, omit に RegExp を指定可能に変更

### DIFF
--- a/.changeset/clean-bags-work.md
+++ b/.changeset/clean-bags-work.md
@@ -1,0 +1,5 @@
+---
+"json-origami": minor
+---
+
+feat: #33 pick, omit に RegExp を指定可能に変更

--- a/src/omit.ts
+++ b/src/omit.ts
@@ -33,11 +33,29 @@ export function omit<D extends Dictionary, K extends DeepKeyOf<D>>(
   obj: D,
   keys: K[],
   opt?: OmitOption
-): Omit<D, K> {
+): Omit<D, K>
+
+/**
+ *
+ * @param obj
+ * @param keys
+ * @param opt
+ */
+export function omit<D extends Dictionary, K extends DeepKeyOf<D>>(
+  obj: D,
+  keys: Array<K | RegExp>,
+  opt?: OmitOption
+): Dictionary
+
+export function omit<D extends Dictionary, K extends DeepKeyOf<D>>(
+  obj: D,
+  keys: Array<K | RegExp>,
+  opt?: OmitOption
+): Dictionary {
   const folded = fold(obj)
 
   const targetKeys = new Set(
-    Object.keys(folded).filter((k) => !keys.some((key) => includesKey(key, k, opt)))
+    Object.keys(folded).filter((k) => !keys.some((key) => includesKey(k, key, opt)))
   )
 
   const fixedKeyMap = Object.fromEntries(

--- a/src/pick.ts
+++ b/src/pick.ts
@@ -34,11 +34,23 @@ export function pick<D extends Dictionary, K extends DeepKeyOf<D>>(
   obj: D,
   keys: K[],
   opt?: PickOption
+): Omit<D, K>
+
+export function pick<D extends Dictionary, K extends DeepKeyOf<D>>(
+  obj: D,
+  keys: Array<K | RegExp>,
+  opt?: PickOption
+): Omit<D, K>
+
+export function pick<D extends Dictionary, K extends DeepKeyOf<D>>(
+  obj: D,
+  keys: Array<K | RegExp>,
+  opt?: PickOption
 ): Omit<D, K> {
   const folded = fold(obj)
 
   const targetKeys = new Set(
-    Object.keys(folded).filter((k) => keys.some((key) => includesKey(key, k, opt)))
+    Object.keys(folded).filter((k) => keys.some((key) => includesKey(k, key, opt)))
   )
 
   const fixedKeyMap = Object.fromEntries(

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -11,21 +11,23 @@ import { defaultCommonOption, type CommonOption } from './type'
  * includesKey("foo.bar.baz", "f", { arrayIndex: "bracket" }) // => false
  * ```
  * @param origin
- * @param key
+ * @param match
  * @param option
  */
 export function includesKey(
   origin: string,
-  key: string,
+  match: string | RegExp,
   { arrayIndex }: CommonOption = defaultCommonOption
 ): boolean {
+  if (match instanceof RegExp) return match.test(origin)
+
   const split = (key: string): string[] => {
     const fixedKey = arrayIndex === 'bracket' ? key.replace(/\[(\w+)\]/g, '.$1') : key
     return fixedKey.split('.')
   }
 
   const originKeys = split(origin)
-  const keys = split(key)
+  const keys = split(match)
 
   if (keys.length > originKeys.length) return false
 

--- a/test/omit.spec.ts
+++ b/test/omit.spec.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines */
 /* eslint-disable max-lines-per-function */
 import { describe, it, expect } from 'vitest'
 import { omit } from '../src/omit'
@@ -117,6 +118,43 @@ describe('omit', () => {
     const result = omit(obj, ['a', 'ba'])
     expect(result).toEqual({
       cba: 3
+    })
+  })
+
+  it('should handle RegExp keys', () => {
+    const obj = {
+      a: {
+        b: {
+          cde: 1
+        },
+        bc: {
+          de: 2
+        },
+        bcd: {
+          e: 3
+        }
+      },
+      ab: {
+        c: {
+          de: 4
+        },
+        cd: {
+          e: 5
+        }
+      },
+      abc: {
+        d: {
+          e: 6
+        }
+      }
+    }
+    const result = omit(obj, [/^a\.b/, /\.e$/])
+    expect(result).toEqual({
+      ab: {
+        c: {
+          de: 4
+        }
+      }
     })
   })
 })

--- a/test/pick.spec.ts
+++ b/test/pick.spec.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines */
 /* eslint-disable max-lines-per-function */
 import { describe, it, expect } from 'vitest'
 import { pick } from '../src/pick'
@@ -110,6 +111,59 @@ describe('pick', () => {
     expect(result).toEqual({
       a: 1,
       ba: 2
+    })
+  })
+
+  it('should handle RegExp keys', () => {
+    const obj = {
+      a: {
+        b: {
+          cde: 1
+        },
+        bc: {
+          de: 2
+        },
+        bcd: {
+          e: 3
+        }
+      },
+      ab: {
+        c: {
+          de: 4
+        },
+        cd: {
+          e: 5
+        }
+      },
+      abc: {
+        d: {
+          e: 6
+        }
+      }
+    }
+    const result = pick(obj, [/^a\.b/, /\.e$/])
+    expect(result).toEqual({
+      a: {
+        b: {
+          cde: 1
+        },
+        bc: {
+          de: 2
+        },
+        bcd: {
+          e: 3
+        }
+      },
+      ab: {
+        cd: {
+          e: 5
+        }
+      },
+      abc: {
+        d: {
+          e: 6
+        }
+      }
     })
   })
 })


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

リリースノート:

- 新機能: `pick`および`omit`関数で正規表現を指定できるようになりました。これにより、より柔軟なキーの選択と除外が可能になります。
- テスト: `pick`および`omit`関数の新機能に対するテストケースを追加しました。これにより、正規表現キーの取り扱いが正しく行われていることを確認します。
- その他: "json-origami"ライブラリに関連するマイナーチェンジを含みます。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->