### PR TITLE
fix: remove dependencies

### DIFF
--- a/.changeset/tough-roses-ring.md
+++ b/.changeset/tough-roses-ring.md
@@ -1,0 +1,5 @@
+---
+"json-origami": patch
+---
+
+fix: remove dependencies

--- a/package.json
+++ b/package.json
@@ -49,9 +49,6 @@
     "format": "biome format --write ./src ./test",
     "lint": "biome check --apply ./src ./test"
   },
-  "dependencies": {
-    "type-fest": "^2.19.0"
-  },
   "devDependencies": {
     "@astrojs/check": "^0.4.1",
     "@astrojs/starlight": "^0.17.2",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "lint": "biome check --apply ./src ./test"
   },
   "dependencies": {
-    "type-fest": "^3.13.0"
+    "type-fest": "^2.19.0"
   },
   "devDependencies": {
     "@astrojs/check": "^0.4.1",

--- a/src/lib/modifier.ts
+++ b/src/lib/modifier.ts
@@ -1,4 +1,3 @@
-import type { Get } from 'type-fest'
 import type { Dictionary, DictionaryLeaf } from '~/type'
 import { type KeyOption, splitHead, splitTails } from './string'
 
@@ -34,7 +33,6 @@ interface ObjectModifier<T extends Dictionary = Dictionary> {
    * modifier.get('a.b.c') // 'd'
    * ```
    */
-  get<K extends string>(key: K): Get<T, K>
   get(key: string): unknown
 
   /**
@@ -64,7 +62,6 @@ interface ObjectModifier<T extends Dictionary = Dictionary> {
    * modifier.set('a.b.c', 'e')
    * ```
    */
-  set<K extends string>(key: K, value: Get<T, K>): boolean
   set(key: string, value: unknown): boolean
 
   /**

--- a/test/omit.bench.ts
+++ b/test/omit.bench.ts
@@ -1,7 +1,7 @@
-import type { JsonObject } from 'type-fest'
 import { bench, describe } from 'vitest'
 import { fold } from '~/fold'
 import { omit } from '~/omit'
+import type { Dictionary } from '~/type'
 import {
   BENCHMARK_TARGET_LIGHT_OBJECT_VALUES,
   BENCHMARK_TARGET_OBJECT_VALUES,
@@ -24,7 +24,7 @@ interface TestCaseOption {
 }
 
 interface TestCase {
-  object: JsonObject
+  object: Dictionary
   keys: string[]
 }
 

--- a/test/pick.bench.ts
+++ b/test/pick.bench.ts
@@ -1,7 +1,7 @@
-import type { JsonObject } from 'type-fest'
 import { bench, describe } from 'vitest'
 import { fold } from '~/fold'
 import { pick } from '~/pick'
+import type { Dictionary } from '~/type'
 import {
   BENCHMARK_TARGET_LIGHT_OBJECT_VALUES,
   BENCHMARK_TARGET_OBJECT_VALUES,
@@ -24,7 +24,7 @@ interface TestCaseOption {
 }
 
 interface TestCase {
-  object: JsonObject
+  object: Dictionary
   keys: string[]
 }
 

--- a/test/utils/factory.ts
+++ b/test/utils/factory.ts
@@ -1,4 +1,4 @@
-import type { JsonArray, JsonObject, JsonValue, Writable } from 'type-fest'
+import type { Dictionary } from '~/type'
 import { createRandomWord, dice, randomChoice } from './random'
 
 const DEFAULT_LEAFS = 1000
@@ -7,7 +7,7 @@ interface RandomObjectOption {
   leafs: number
 }
 
-export function createRandomObject({ leafs }: RandomObjectOption): JsonObject {
+export function createRandomObject({ leafs }: RandomObjectOption): Dictionary {
   let leafCount = 0
 
   if (leafs % 1 !== 0) {
@@ -31,8 +31,8 @@ export function createRandomObject({ leafs }: RandomObjectOption): JsonObject {
     return leafCount % 2 === 0
   }
 
-  function createObject({ root }: { root?: boolean } = {}): JsonObject {
-    const obj: JsonObject = {}
+  function createObject({ root }: { root?: boolean } = {}): Dictionary {
+    const obj: Dictionary = {}
 
     while ((root || dice(0.6)) && leafCount < maxLeafs) {
       const key = createRandomWord()
@@ -52,8 +52,8 @@ export function createRandomObject({ leafs }: RandomObjectOption): JsonObject {
     return obj
   }
 
-  function createArray(): JsonArray {
-    const arr: Writable<JsonArray> = []
+  function createArray(): Dictionary {
+    const arr: Dictionary = []
 
     while (dice(0.3) && leafCount < maxLeafs) {
       const value = createValue()
@@ -67,7 +67,7 @@ export function createRandomObject({ leafs }: RandomObjectOption): JsonObject {
     return arr
   }
 
-  function createValue(): JsonValue {
+  function createValue(): Dictionary {
     type ValueType = 'number' | 'string' | 'boolean' | 'object' | 'array'
 
     const map = {
@@ -76,7 +76,7 @@ export function createRandomObject({ leafs }: RandomObjectOption): JsonObject {
       boolean: createBooleanLeaf,
       object: createObject,
       array: createArray,
-    } satisfies Record<ValueType, () => JsonValue>
+    } satisfies Record<ValueType, () => Dictionary>
 
     return map[
       randomChoice([

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -41,5 +41,5 @@
     }
   },
   "exclude": ["node_modules", "dist"],
-  "include": ["src/**/*", "tests/**/*"]
+  "include": ["./src/**/*", "./tests/**/*"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5154,7 +5154,7 @@ __metadata:
     defu: "npm:^6.1.4"
     sharp: "npm:^0.33.2"
     tsup: "npm:^8.0.1"
-    type-fest: "npm:^3.13.0"
+    type-fest: "npm:^2.19.0"
     typescript: "npm:^5.3.3"
     vitest: "npm:^1.2.2"
   peerDependencies:
@@ -8784,17 +8784,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"type-fest@npm:^2.13.0":
+"type-fest@npm:^2.13.0, type-fest@npm:^2.19.0":
   version: 2.19.0
   resolution: "type-fest@npm:2.19.0"
   checksum: 10/7bf9e8fdf34f92c8bb364c0af14ca875fac7e0183f2985498b77be129dc1b3b1ad0a6b3281580f19e48c6105c037fb966ad9934520c69c6434d17fd0af4eed78
-  languageName: node
-  linkType: hard
-
-"type-fest@npm:^3.13.0":
-  version: 3.13.1
-  resolution: "type-fest@npm:3.13.1"
-  checksum: 10/9a8a2359ada34c9b3affcaf3a8f73ee14c52779e89950db337ce66fb74c3399776c697c99f2532e9b16e10e61cfdba3b1c19daffb93b338b742f0acd0117ce12
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5154,7 +5154,6 @@ __metadata:
     defu: "npm:^6.1.4"
     sharp: "npm:^0.33.2"
     tsup: "npm:^8.0.1"
-    type-fest: "npm:^2.19.0"
     typescript: "npm:^5.3.3"
     vitest: "npm:^1.2.2"
   peerDependencies:
@@ -8784,7 +8783,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"type-fest@npm:^2.13.0, type-fest@npm:^2.19.0":
+"type-fest@npm:^2.13.0":
   version: 2.19.0
   resolution: "type-fest@npm:2.19.0"
   checksum: 10/7bf9e8fdf34f92c8bb364c0af14ca875fac7e0183f2985498b77be129dc1b3b1ad0a6b3281580f19e48c6105c037fb966ad9934520c69c6434d17fd0af4eed78


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **リファクタ**
	- `ObjectModifier` インターフェースの `get` と `set` メソッドが、一般的な `K extends string` から `string` キーを受け入れるように変更されました。
- **テスト**
	- ベンチマークテストの型インポートを `type-fest` からローカルの `~/type` に変更し、`TestCase` インターフェースの `object` プロパティの型を `JsonObject` から `Dictionary` に更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->