### PR TITLE
chore(security): replace npx with yarn in lefthook pre-commit

### DIFF
--- a/lefthook.yaml
+++ b/lefthook.yaml
@@ -3,7 +3,7 @@ pre-commit:
   commands:
     biome:
       glob: "*.{js,ts,cjs,mjs,d.cts,d.mts,jsx,tsx,json,jsonc}"
-      run: npx biome check --no-errors-on-unmatched --files-ignore-unknown=true {staged_files}
+      run: yarn biome check --no-errors-on-unmatched --files-ignore-unknown=true {staged_files}
 
     actionlint:
       glob: "./.github/**/*.yml"


### PR DESCRIPTION
## 背景

`npx` は呼び出しごとに npm registry から最新版を取得して実行するため、
lockfile によるバージョン固定が効かず、サプライチェーン攻撃 (Mini Shai-Hulud 2nd 等)
の侵入経路になりうる。

`@biomejs/biome` は `devDependencies` に固定されているので、`yarn biome` 経由で
実行すれば lockfile に固定されたバージョンが使われる。

## 変更

`lefthook.yaml` の pre-commit hook を `npx biome` → `yarn biome` に置換。

```diff
- run: npx biome check --no-errors-on-unmatched --files-ignore-unknown=true {staged_files}
+ run: yarn biome check --no-errors-on-unmatched --files-ignore-unknown=true {staged_files}
```

## 動作確認

ローカルで `yarn` install 済みの状態で commit すると、`yarn biome check` が pre-commit hook で動作することを確認する。

## 参考

- https://blog.flatt.tech/entry/mini_shai_hulud_2nd

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * プリコミットフック時のコード品質チェック処理を改善するため、開発環境の設定を更新しました。新しい設定により、コードの検証プロセスがより効率的かつ柔軟になり、開発チームの生産性向上に貢献します。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hacomono-lib/json-origami/pull/239)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->