### PR TITLE
chore(security): introduce Takumi Guard composite action for GitHub Actions

### DIFF
--- a/.github/actions/takumi-guard-setup/action.yml
+++ b/.github/actions/takumi-guard-setup/action.yml
@@ -1,0 +1,8 @@
+name: 'Takumi Guard setup'
+description: 'Configure package registries to route through Takumi Guard'
+runs:
+  using: 'composite'
+  steps:
+    - uses: flatt-security/setup-takumi-guard-npm@9a5d797c2085b6326d3a2985c08e3a114b9b88c1 # v1
+      with:
+        bot-id: "BT01KRJ741G9T8KN3Y91SHA5KF1F"

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -30,16 +30,28 @@ jobs:
     if: |
       !contains(github.event.pull_request.labels.*.name, 'renovate') && github.event.pull_request.title != 'Version Packages'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: read
+      pull-requests: write
+      id-token: write
     steps:
       - uses: actions/checkout@v4
+      - uses: ./.github/actions/takumi-guard-setup
       - uses: ./.github/actions/init-node
 
   benchmarks:
     runs-on: ubuntu-latest
     needs:
       - init__node
+    permissions:
+      contents: read
+      packages: read
+      pull-requests: write
+      id-token: write
     steps:
       - uses: actions/checkout@v4
+      - uses: ./.github/actions/takumi-guard-setup
       - uses: ./.github/actions/init-node
 
       - name: Run benchmarks

--- a/.github/workflows/document.yml
+++ b/.github/workflows/document.yml
@@ -15,8 +15,13 @@ permissions:
 jobs:
   init__node:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
     steps:
       - uses: actions/checkout@v4
+      - uses: ./.github/actions/takumi-guard-setup
       - uses: ./.github/actions/init-node
 
   build-doc:
@@ -24,8 +29,13 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - init__node
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
     steps:
       - uses: actions/checkout@v4
+      - uses: ./.github/actions/takumi-guard-setup
       - uses: ./.github/actions/init-node
 
       - run: yarn doc-build

--- a/.github/workflows/lint__actions.yml
+++ b/.github/workflows/lint__actions.yml
@@ -18,8 +18,14 @@ jobs:
   actionlint:
     name: "Lint: GitHub Actions"
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: read
+      pull-requests: write
+      id-token: write
     steps:
       - uses: actions/checkout@v4
+      - uses: ./.github/actions/takumi-guard-setup
 
       - name: github actions lint
         uses: reviewdog/action-actionlint@v1

--- a/.github/workflows/lint__codebase.yml
+++ b/.github/workflows/lint__codebase.yml
@@ -16,8 +16,14 @@ jobs:
     if: |
       !contains(github.event.pull_request.labels.*.name, 'renovate')
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: read
+      pull-requests: write
+      id-token: write
     steps:
       - uses: actions/checkout@v4
+      - uses: ./.github/actions/takumi-guard-setup
 
       - uses: ./.github/actions/init-node
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,9 +18,16 @@ jobs:
   release:
     name: "Release"
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      packages: write
+      pull-requests: write
+      id-token: write
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
+
+    - uses: ./.github/actions/takumi-guard-setup
 
     - name: Install dependencies
       uses: ./.github/actions/init-node

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,8 +28,14 @@ jobs:
         github.event.pull_request.title != 'Version Packages'
     name: "Initialize: node"
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: read
+      pull-requests: write
+      id-token: write
     steps:
       - uses: actions/checkout@v4
+      - uses: ./.github/actions/takumi-guard-setup
       - uses: ./.github/actions/init-node
 
   build:
@@ -37,8 +43,14 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - init__node
+    permissions:
+      contents: read
+      packages: read
+      pull-requests: write
+      id-token: write
     steps:
       - uses: actions/checkout@v4
+      - uses: ./.github/actions/takumi-guard-setup
       - uses: ./.github/actions/init-node
 
       - uses: ./.github/actions/build-and-cache
@@ -48,8 +60,14 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - build
+    permissions:
+      contents: read
+      packages: read
+      pull-requests: write
+      id-token: write
     steps:
       - uses: actions/checkout@v4
+      - uses: ./.github/actions/takumi-guard-setup
       - uses: ./.github/actions/init-node
       - uses: ./.github/actions/build-and-cache
 
@@ -60,8 +78,14 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - init__node
+    permissions:
+      contents: read
+      packages: read
+      pull-requests: write
+      id-token: write
     steps:
       - uses: actions/checkout@v4
+      - uses: ./.github/actions/takumi-guard-setup
       - uses: ./.github/actions/init-node
 
       - run: yarn test:type
@@ -71,8 +95,14 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - init__node
+    permissions:
+      contents: read
+      packages: read
+      pull-requests: write
+      id-token: write
     steps:
       - uses: actions/checkout@v4
+      - uses: ./.github/actions/takumi-guard-setup
       - uses: ./.github/actions/init-node
 
       - run: yarn test:doc


### PR DESCRIPTION
## 背景

npm を中心とした supply chain 攻撃 (Shai-Hulud 類似事象) への予防対応として、Takumi Guard をこの repo の GitHub Actions に導入します。
詳細は社内インシデント Plan を参照してください。

## 変更内容

- `.github/actions/takumi-guard-setup/action.yml` を新規作成 (この repo で使う ecosystem の setup-takumi-guard-* を束ねる composite action)
- 既存の各 workflow の各 job について、`actions/checkout` の直後に `uses: ./.github/actions/takumi-guard-setup` を 1 行追記
- 上記 job の `permissions:` に `id-token: write` と `contents: read` をマージ (既存値は保持。root level の permissions ブロックは触らず、root の全キー + `id-token: write` の union を job level に展開)
- `flatt-security/setup-takumi-guard-*` は third-party action のため 40-char commit SHA で pin

## レビュー観点

- composite action にハードコードされた `bot-id` が、この repo が属する org と一致していること
- CI が green であること (id-token 周りで失敗する場合は permissions マージが効いているか確認)
- Renovate / Dependabot が生成する PR の CI でも新 step が正しく走ること

Plan reference: `plan.sha256:f75721c41ccec727f7e05def986a7e2fed7e94e02d8d29c5ca0299e88c3afd8f / executed by mew-ton@hacomono / 2026-05-14T18:30+09:00`

Closes #240
